### PR TITLE
Slight change for GLI-2 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,2 @@
 source :rubygems
 gemspec
-gem 'gli'
-gem 'blather'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,35 +3,43 @@ PATH
   specs:
     P1PP (0.0.1)
       blather
-      gli
+      gli (~> 2)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.1.3)
+    activesupport (3.2.9)
+      i18n (~> 0.6)
       multi_json (~> 1.0)
-    blather (0.5.12)
-      activesupport (>= 3.0.7)
+    blather (0.8.1)
+      activesupport (>= 2.3.11)
       eventmachine (>= 0.12.6)
-      niceogiri (>= 0.1.0)
-      nokogiri (~> 1.4.0)
-    eventmachine (0.12.10)
-    gli (1.4.0)
+      girl_friday
+      niceogiri (~> 1.0)
+      nokogiri (~> 1.5.5)
+    connection_pool (0.9.2)
+    eventmachine (1.0.0)
+    girl_friday (0.11.1)
+      connection_pool (~> 0.9.0)
+      rubinius-actor
+    gli (2.5.0)
+    i18n (0.6.1)
     json (1.6.4)
-    multi_json (1.0.4)
-    niceogiri (0.1.1)
-      nokogiri (~> 1.4.6)
-    nokogiri (1.4.7)
+    multi_json (1.3.7)
+    niceogiri (1.1.1)
+      nokogiri (~> 1.5)
+    nokogiri (1.5.5)
     rake (0.9.2.2)
     rdoc (3.12)
       json (~> 1.4)
+    rubinius-actor (0.0.2)
+      rubinius-core-api
+    rubinius-core-api (0.0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   P1PP!
-  blather
-  gli
   rake
   rdoc

--- a/bin/p1.rb
+++ b/bin/p1.rb
@@ -19,7 +19,7 @@ require 'p1pp/p1_publisher'
 require 'p1pp/p1_subscriber'
 require 'p1pp/p1_error'
 
-include GLI
+include GLI::App
 
 program_desc 'This is a command-line interface tool to ProcessOne Push Platform'
 
@@ -129,4 +129,4 @@ on_error do |exception|
   true
 end
 
-exit GLI.run(ARGV)
+exit run(ARGV)

--- a/p1pp.gemspec
+++ b/p1pp.gemspec
@@ -20,5 +20,5 @@ spec = Gem::Specification.new do |s|
   s.add_development_dependency('rake')
   s.add_development_dependency('rdoc')
   s.add_dependency('blather')
-  s.add_dependency('gli')
+  s.add_dependency('gli', "~> 2")
 end


### PR DESCRIPTION
This removes the deps from the Gemfile, which aren't needed, and
firms up the version of GLI in the gemspec, as well as
making two small changes for GLI-2 compatibility.

Users installing this via RubyGems will get the correct version
of GLI

**Merge this if you are comfortable updating to GLI2**  GLI2 is solid and has some cool new features, so this should be safe.

I'm sending another pull request to make things work if you _don't_ want to update to GLI 2
