### PR TITLE
Firm up dep for GLI1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,2 @@
 source :rubygems
 gemspec
-gem 'gli'
-gem 'blather'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,35 +3,43 @@ PATH
   specs:
     P1PP (0.0.1)
       blather
-      gli
+      gli (~> 1)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.1.3)
+    activesupport (3.2.9)
+      i18n (~> 0.6)
       multi_json (~> 1.0)
-    blather (0.5.12)
-      activesupport (>= 3.0.7)
+    blather (0.8.1)
+      activesupport (>= 2.3.11)
       eventmachine (>= 0.12.6)
-      niceogiri (>= 0.1.0)
-      nokogiri (~> 1.4.0)
-    eventmachine (0.12.10)
+      girl_friday
+      niceogiri (~> 1.0)
+      nokogiri (~> 1.5.5)
+    connection_pool (0.9.2)
+    eventmachine (1.0.0)
+    girl_friday (0.11.1)
+      connection_pool (~> 0.9.0)
+      rubinius-actor
     gli (1.4.0)
+    i18n (0.6.1)
     json (1.6.4)
-    multi_json (1.0.4)
-    niceogiri (0.1.1)
-      nokogiri (~> 1.4.6)
-    nokogiri (1.4.7)
+    multi_json (1.3.7)
+    niceogiri (1.1.1)
+      nokogiri (~> 1.5)
+    nokogiri (1.5.5)
     rake (0.9.2.2)
     rdoc (3.12)
       json (~> 1.4)
+    rubinius-actor (0.0.2)
+      rubinius-core-api
+    rubinius-core-api (0.0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   P1PP!
-  blather
-  gli
   rake
   rdoc

--- a/p1pp.gemspec
+++ b/p1pp.gemspec
@@ -20,5 +20,5 @@ spec = Gem::Specification.new do |s|
   s.add_development_dependency('rake')
   s.add_development_dependency('rdoc')
   s.add_dependency('blather')
-  s.add_dependency('gli')
+  s.add_dependency('gli', "~> 1")
 end


### PR DESCRIPTION
This ensures that users who install this via RubyGems
do not get GLI2 installed, which is incompatible with
the version of p1pp currently on master.

**Merge this if you don't want to update to GLI2**

This would've helped the person here: http://stackoverflow.com/questions/13515299/trouble-running-p1pp-gli-run-no-longer-works-for-gli-2
